### PR TITLE
Removed duplicated "Lokku" entries

### DIFF
--- a/Perl_Companies.csv
+++ b/Perl_Companies.csv
@@ -2495,8 +2495,6 @@
 "Lok Technology", "United States, CA, San Jose", "2007", "Dormant"
 "Lok Technology, Inc.", "United States, Florida, Vero Beach", "2005", "Dormant"
 "Lokku", "United Kingdom, Central London", "2013", "Active"
-"Lokku Limited", "United Kingdom, London", "2007", "Dormant"
-"Lokku Ltd.", "United Kingdom, London", "2010", "Inactive"
 "London Music Thing", "United Kingdom, London, London", "2006", "Dormant"
 "London School of Economics and Political Science", "United Kingdom, London, London", "2008", "Dormant"
 "London South Bank University/Thames Computer Services", "United Kingdom, Central London, London", "2010", "Inactive"

--- a/Perl_Companies.md
+++ b/Perl_Companies.md
@@ -2509,8 +2509,6 @@ Most of the table below is self-explanatory, save the 'Hiring Status' column. An
 <tr><td>Lok Technology</td><td>United States, CA, San Jose</td><td>2007</td><td>Dormant</td></tr>
 <tr><td>Lok Technology, Inc.</td><td>United States, Florida, Vero Beach</td><td>2005</td><td>Dormant</td></tr>
 <tr><td>Lokku</td><td>United Kingdom, Central London</td><td>2013</td><td>Active</td></tr>
-<tr><td>Lokku Limited</td><td>United Kingdom, London</td><td>2007</td><td>Dormant</td></tr>
-<tr><td>Lokku Ltd.</td><td>United Kingdom, London</td><td>2010</td><td>Inactive</td></tr>
 <tr><td>London Music Thing</td><td>United Kingdom, London, London</td><td>2006</td><td>Dormant</td></tr>
 <tr><td>London School of Economics and Political Science</td><td>United Kingdom, London, London</td><td>2008</td><td>Dormant</td></tr>
 <tr><td>London South Bank University/Thames Computer Services</td><td>United Kingdom, Central London, London</td><td>2010</td><td>Inactive</td></tr>


### PR DESCRIPTION
I am CTO at Lokku Ltd., the company behind the Nestoria property search engine.

There were three different entries for us from the jobs.perl.org scraping as we've been inconsistent about our usage of Lokku, Lokku Ltd, etc. as our name.

I kept the most recent one, which was from the jobs we posted in 2013.
